### PR TITLE
Add dependencies for the summary.png

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="python3-venv python3-dev python3-pip sqlite3"
+pkg_dependencies="python3-venv python3-dev python3-pip sqlite3 wkhtmltopdf optipng"
 
 yunorunner_repository="https://github.com/YunoHost/yunorunner"
 


### PR DESCRIPTION
## Problem

package_check needs wkhtmltopdf and optipng to generate summary.png
See https://github.com/YunoHost/package_check/blob/f1ede681b07a620c3d37d22ee41825d757f3d234/lib/analyze_test_results.py#L296-L301

## Solution

- Add apt dependencies

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
