### PR TITLE
Fix git commands

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,8 +114,8 @@ then
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	pushd "$final_path"
-		git fetch --quiet --depth=1 origin "$yunorunner_release"
-		git reset --quiet --hard FETCH_HEAD
+		ynh_exec_as $app git fetch --quiet --depth=1 origin "$yunorunner_release"
+		ynh_exec_as $app git reset --quiet --hard FETCH_HEAD
 	popd
 fi
 


### PR DESCRIPTION
Upgrades fail with 

```
Info: [########+...........] > Upgrading source files...
Warning: fatal: detected dubious ownership in repository at '/var/www/yunorunner'
Warning: To add an exception for this directory, call:
Warning:        git config --global --add safe.directory /var/www/yunorunner
Warning: [Error] Upgrade failed.
```

```
 git --version
git version 2.30.2
```

Solved by using `ynh_exec_as` since `$final_path` is owned by `$app`.

FIXME: fails if the remote is set as ssh address and not plain http.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
