### PR TITLE
Remove obsolete disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,10 @@ CI runner of YunoHost
 
 ![Screenshot of YunoRunner](./doc/screenshots/screenshot.png)
 
-## Disclaimers / important information
-
-## Limitations
-
-* You need to install [CI_package_check](https://github.com/YunoHost/CI_package_check) using the `install.sh` script before installing YunoRunner
-* When YunoRunner is installed, modify the systemd script to add the path of the script `analyseCI.sh`. The default systemd is configured to `/home/CI_package_check/analyseCI.sh`
-
 ## Documentation and resources
 
 * Upstream app code repository: <https://github.com/YunoHost/yunorunner>
-* YunoHost documentation for this app: <https://yunohost.org/app_yunorunner>
+* YunoHost Store: <https://apps.yunohost.org/app/yunorunner>
 * Report a bug: <https://github.com/YunoHost-Apps/yunorunner_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,17 +24,10 @@ Runner d'intégration continue de YunoHost
 
 ![Capture d’écran de YunoRunner](./doc/screenshots/screenshot.png)
 
-## Avertissements / informations importantes
-
-## Limitations
-
-* You need to install [CI_package_check](https://github.com/YunoHost/CI_package_check) using the `install.sh` script before installing YunoRunner
-* When YunoRunner is installed, modify the systemd script to add the path of the script `analyseCI.sh`. The default systemd is configured to `/home/CI_package_check/analyseCI.sh`
-
 ## Documentations et ressources
 
 * Dépôt de code officiel de l’app : <https://github.com/YunoHost/yunorunner>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_yunorunner>
+* YunoHost Store: <https://apps.yunohost.org/app/yunorunner>
 * Signaler un bug : <https://github.com/YunoHost-Apps/yunorunner_ynh/issues>
 
 ## Informations pour les développeurs

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,4 +1,0 @@
-## Limitations
-
-* You need to install [CI_package_check](https://github.com/YunoHost/CI_package_check) using the `install.sh` script before installing YunoRunner
-* When YunoRunner is installed, modify the systemd script to add the path of the script `analyseCI.sh`. The default systemd is configured to `/home/CI_package_check/analyseCI.sh`


### PR DESCRIPTION
## Problem

There's obsolete documentation in README. [CI_package_check](https://github.com/YunoHost/CI_package_check) is archived and I couldn't find any reference to `analyseCI.sh` script in [yunnorunner](https://github.com/YunoHost/yunorunner) and [package_check](https://github.com/YunoHost/package_check). I've also installed Yunorunner from app package locally and it didn't break due to missing CI_package_check(even when running test jobs).

## Solution

Removed obsolete disclaimer from documentation.

## PR Status

- [x] Code finished and ready to be reviewed/tested

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
